### PR TITLE
fix(README): address modal ambiguity

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Main
       - Price range
       - Open / Closed
       - Restaurant name
-      - Learn more (open modal to show more details)
+      - Learn more (navigate to Detail View)
 Detail View
   - Restaurant Name & Rating
   - Map (optional, if time allows)


### PR DESCRIPTION
Currently the designs have the `Detail View` structured as a stand alone page but the README implies that it should live in a modal. This removes the modal wording to standardize on a separate page implementation. 